### PR TITLE
feat: Add PDF export with Typst

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,9 @@ jobs:
     - name: List installed packages
       run: pixi list
 
+    - name: Build the PDF export with Typst
+      run: pixi run pdf
+
     - name: Build the site
       run: pixi run build
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -468,6 +468,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/typst-0.14.0-h4c46f8d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
       osx-arm64:
@@ -490,6 +491,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/typst-0.14.0-hd1458d2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_2.conda
 packages:
@@ -3974,6 +3976,30 @@ packages:
   license_family: APACHE
   size: 15183
   timestamp: 1733331395943
+- conda: https://conda.anaconda.org/conda-forge/linux-64/typst-0.14.0-h4c46f8d_0.conda
+  sha256: ab784b2a296f9f69c4ad8e839bfb286dd2153b125f5eb06a8b996ef8b6ca6796
+  md5: 7f1ba4988d4d54ecfd6e6b626728e2b8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - openssl >=3.5.4,<4.0a0
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0
+  license_family: Apache
+  size: 15434892
+  timestamp: 1761303336812
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/typst-0.14.0-hd1458d2_0.conda
+  sha256: fc24ac83cd71395f38a9d084e481e0e168834e157364cf3125e230ce4b57aebd
+  md5: 6591c72f6d6a0476b2944e0029ef0469
+  depends:
+  - __osx >=11.0
+  constrains:
+  - __osx >=11.0
+  license: Apache-2.0
+  license_family: Apache
+  size: 14684131
+  timestamp: 1761304275500
 - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
   sha256: 5aaa366385d716557e365f0a4e9c3fca43ba196872abbbe3d56bb610d131e192
   md5: 4222072737ccff51314b5ece9c7d6f5a

--- a/pixi.toml
+++ b/pixi.toml
@@ -10,6 +10,11 @@ description = "Build report as static HTML website"
 cmd = "myst build --html"
 cwd = "report"
 
+[tasks.pdf]
+description = "Build PDF export of report"
+cmd = "myst build --pdf"
+cwd = "report"
+
 [tasks.clean]
 description = "Remove exports, temp files and installed templates"
 cmd = "myst clean --yes"
@@ -22,6 +27,7 @@ description = "Start a local server to preview the report"
 
 [dependencies]
 mystmd = ">=1.6.3,<2"
+typst = ">=0.14.0,<0.15"
 
 [feature.analysis.dependencies]
 pandas = ">=2.3.3,<3"

--- a/report/report.md
+++ b/report/report.md
@@ -1,3 +1,13 @@
+---
+exports:
+  - format: pdf
+    template: lapreprint-typst
+    output: exports/feickert-urssi-report-2025.pdf
+    id: feickert-urssi-report-2025
+downloads:
+  - id: feickert-urssi-report-2025
+    title: PDF export
+---
 # Matthew Feickert's 2025 URSSI Early-Career Fellowship Report
 
 As part of inaugural US Research Software Sustainability Institute (URSSI) Early-Career Fellow Matthew Feickert's fellowship research, he developed an open source course on creating reproducible software environments for scientific and AI/ML applications.


### PR DESCRIPTION
* Add Typst to Pixi environment.
* Add PDF export frontmatter to report.
   - c.f. https://mystmd.org/guide/website-downloads#include-exported-pdf
* Add PDF export Pixi command.
* Build PDF export before building site in CD GHA workflow.